### PR TITLE
Allow building on FreeBSD

### DIFF
--- a/cmd/pgmetrics/system_freebsd.go
+++ b/cmd/pgmetrics/system_freebsd.go
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 RapidLoop, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+func (c *collector) collectSystem(o options) {
+	// Not implemented for FreeBSD yet.
+}


### PR DESCRIPTION
I just copied the Empty file from Darwin to get through the build.

I've created an offical port for FreeBSD as well, so perhaps you could add the instruction to install in FreeBSD as `pkg install pgmetrics`?