### PR TITLE
allow pgmetric to be used as library

### DIFF
--- a/cmd/pgmetrics/collect.go
+++ b/cmd/pgmetrics/collect.go
@@ -48,7 +48,7 @@ func makeKV(k, v string) string {
 	return fmt.Sprintf("%s=%s ", k, v2)
 }
 
-func collect(o options, args []string) *pgmetrics.Model {
+func Collect(o options, args []string) *pgmetrics.Model {
 	// form connection string
 	var connstr string
 	if len(o.host) > 0 {

--- a/cmd/pgmetrics/main.go
+++ b/cmd/pgmetrics/main.go
@@ -405,7 +405,7 @@ func main() {
 		result = &obj
 		f.Close()
 	} else {
-		result = collect(o, args)
+		result = Collect(o, args)
 	}
 
 	// process it


### PR DESCRIPTION
Fixes: https://github.com/rapidloop/pgmetrics/issues/13

pgmetrics is a great command-line tool. but running this specific commandline in every environment is not ideal.

* pgmetrics.Model is already available to other packages.
* making `collect` public, it can be used as library.

this is the minimal change one can do to make it work like a library. separating it out as a real library can be taken as a separate task and i think it would be only necessary if this simple setup doesn't work.