### PR TITLE
Added missing column ClCancelReq for SHOW POOLS

### DIFF
--- a/collector/collect.go
+++ b/collector/collect.go
@@ -2332,7 +2332,7 @@ func (c *collector) getPBPools() {
 		var pool pgmetrics.PgBouncerPool
 		var maxWaitUs float64
 		if err := rows.Scan(&pool.Database, &pool.UserName, &pool.ClActive,
-			&pool.ClWaiting, &pool.SvActive, &pool.SvIdle, &pool.SvUsed,
+			&pool.ClWaiting, &pool.ClCancelReq, &pool.SvActive, &pool.SvIdle, &pool.SvUsed,
 			&pool.SvTested, &pool.SvLogin, &pool.MaxWait, &maxWaitUs, &pool.Mode); err != nil {
 			log.Fatalf("show pools query failed: %v", err)
 		}


### PR DESCRIPTION
Added missing column ClCancelReq for SHOW POOLS column cl_cancel_req. This is for pgbouncer version 1.16.0.