### PR TITLE
Skip collecting wal if db is aurora

### DIFF
--- a/collector/collect.go
+++ b/collector/collect.go
@@ -2415,6 +2415,11 @@ func (c *collector) getBloat() {
 }
 
 func (c *collector) getWAL() {
+	// skip if Aurora, because the function errors out with:
+	// "Function pg_stat_get_wal_receiver() is currently not supported in Aurora"
+	if c.isAWSAurora() {
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 


### PR DESCRIPTION
Hello!

I'm was trying to run pgmetrics from linux to get metrics for our AWS RDS Aurora Cluster (14.4), but I was getting the following fatal error when trying to do so.

```
pgmetrics: pg_stat_wal query failed: pq: Function pg_stat_get_wal() is currently not supported for Aurora
```

Aurora not supporting wal metrics seems to be a known issue for pgmetrics, see below:
https://github.com/rapidloop/pgmetrics/blob/35516b55da71f8aa05b84f360032e9ca68b6d830/collector/collect.go#L854-L860


After some investigation, I found that the error was being raised by the `getWal()` function, which is missing the `c.isAWSAurora()` check.
https://github.com/rapidloop/pgmetrics/blob/35516b55da71f8aa05b84f360032e9ca68b6d830/collector/collect.go#L2417-L2436

I recompiled locally with the check and it fixed my issue. 


The call to the `getWal()` function has been introduced more than a year ago. I couldn't find any related issues in the repo, am I the first one to have this issue? 