### PR TITLE
Added schema discovery for pg_stat_statements extension

### DIFF
--- a/cmd/pgmetrics/report.go
+++ b/cmd/pgmetrics/report.go
@@ -908,9 +908,9 @@ Database #%d:
 			fmt.Fprint(fd, `    Installed Extensions:
 `)
 			var tw tableWriter
-			tw.add("Name", "Version", "Comment")
+			tw.add("Name", "Schema", "Version", "Comment")
 			for _, ext := range exts {
-				tw.add(ext.Name, ext.InstalledVersion, ext.Comment)
+				tw.add(ext.Name, ext.SchemaName, ext.InstalledVersion, ext.Comment)
 			}
 			tw.write(fd, "      ")
 			gap = true

--- a/collector/collect.go
+++ b/collector/collect.go
@@ -1971,7 +1971,8 @@ func (c *collector) getStatementsSchema() string {
 	var schema string
 	q := `SELECT extnamespace::regnamespace FROM pg_extension WHERE extname = 'pg_stat_statements'`
 	if err := c.db.QueryRowContext(ctx, q).Scan(&schema); err != nil {
-		log.Fatalf("pg_extension query failed: %v", err)
+		log.Printf("warning: pg_extension query failed: %v", err)
+		return "public"
 	}
 
 	return schema

--- a/collector/collect.go
+++ b/collector/collect.go
@@ -1972,7 +1972,6 @@ func (c *collector) getStatementsSchema() string {
 	q := `SELECT extnamespace::regnamespace FROM pg_extension WHERE extname = 'pg_stat_statements'`
 	if err := c.db.QueryRowContext(ctx, q).Scan(&schema); err != nil {
 		log.Fatalf("pg_extension query failed: %v", err)
-		return "public"
 	}
 
 	return schema

--- a/model.go
+++ b/model.go
@@ -524,6 +524,7 @@ type VacuumProgressBackend struct {
 type Extension struct {
 	Name             string `json:"name"`
 	DBName           string `json:"db_name"`
+	SchemaName       string `json:"schema_name"`
 	DefaultVersion   string `json:"default_version"`
 	InstalledVersion string `json:"installed_version"`
 	Comment          string `json:"comment"`


### PR DESCRIPTION
The database may have a non-standard search_path (standard: `"$user", public`) that does not include the public schema. In this case, you need to discovery which schema the pg_stat_statements extension is installed in and use the full name schema.pg_stat_statements in the query.