### PR TITLE
Correctly reflect "always" archiving mode for WAL Archiving in report

### DIFF
--- a/cmd/pgmetrics/report.go
+++ b/cmd/pgmetrics/report.go
@@ -293,8 +293,8 @@ Logical Replication Slots:
 
 // WAL files and archiving
 func reportWAL(fd io.Writer, result *pgmetrics.Model, version int) {
-
-	archiveMode := getSetting(result, "archive_mode") == "on"
+	mode := getSetting(result, "archive_mode")
+	archiveMode := (mode == "on" || mode == "always")
 	fmt.Fprintf(fd, `
 WAL Files:
     WAL Archiving?       %s`,


### PR DESCRIPTION
There is a new WAL Archiving mode - "always". I have fixed the reporting logic to correctly interpret this value as 'yes'